### PR TITLE
Feat 69/caso de prueba 11

### DIFF
--- a/src/main/java/tpi/backend/e_commerce/dto/orderDTO/CreateOrderDto.java
+++ b/src/main/java/tpi/backend/e_commerce/dto/orderDTO/CreateOrderDto.java
@@ -7,11 +7,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import tpi.backend.e_commerce.dto.orderDetailDto.CreateOrderDetailDto;
 
 @Data
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class CreateOrderDto {
     
     private String userEmail;

--- a/src/main/java/tpi/backend/e_commerce/services/order/SaveOrderService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/order/SaveOrderService.java
@@ -23,6 +23,7 @@ import tpi.backend.e_commerce.repositories.IOrderRepository;
 import tpi.backend.e_commerce.repositories.IProductRepository;
 import tpi.backend.e_commerce.repositories.IUserRepository;
 import tpi.backend.e_commerce.services.order.interfaces.ISaveOrderService;
+import tpi.backend.e_commerce.services.product.interfaces.IModifyProductService;
 import tpi.backend.e_commerce.validation.Validation;
 
 @Service
@@ -39,6 +40,9 @@ public class SaveOrderService implements ISaveOrderService{
 
     @Autowired
     private IProductRepository productRepository;
+
+    @Autowired
+    private IModifyProductService productService;
 
     @Override
     public ResponseEntity<?> create(CreateOrderDto orderDto, BindingResult result) {
@@ -94,7 +98,10 @@ public class SaveOrderService implements ISaveOrderService{
 
             Optional<Product> optionalProduct = productRepository.findById(orderDetailDto.getProductId());
             Product product = optionalProduct.get();
-            product.setStock(product.getStock() - orderDetailDto.getAmount());
+
+            //Le pido al servicio de producto que me descuente el stock
+            product = productService.discountStock(product, orderDetailDto.getAmount());
+
             OrderDetail orderDetailToSave = OrderDetailMapper.toEntity(orderDetailDto,order,product);
 
             orderDetailListToSave.add(orderDetailToSave);

--- a/src/main/java/tpi/backend/e_commerce/services/product/ModifyProductService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/product/ModifyProductService.java
@@ -1,0 +1,16 @@
+package tpi.backend.e_commerce.services.product;
+
+import org.springframework.stereotype.Service;
+
+import tpi.backend.e_commerce.models.Product;
+import tpi.backend.e_commerce.services.product.interfaces.IModifyProductService;
+
+@Service
+public class ModifyProductService implements IModifyProductService {
+
+    @Override
+    public Product discountStock(Product product, Integer discount) {
+        product.setStock(product.getStock() - discount);
+        return product;
+    }
+}

--- a/src/main/java/tpi/backend/e_commerce/services/product/interfaces/IModifyProductService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/product/interfaces/IModifyProductService.java
@@ -1,0 +1,7 @@
+package tpi.backend.e_commerce.services.product.interfaces;
+
+import tpi.backend.e_commerce.models.Product;
+
+public interface IModifyProductService {
+    Product discountStock(Product product, Integer discount);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=e-commerce
-spring.profiles.active=Salvucci 
+spring.profiles.active=Felipe 
 
 token.signing.key=413F4428472B4B6250655368566D5970337336763979244226452948404D6351
 

--- a/src/test/java/tpi/backend/e_commerce/orderTests/unitTests/TestOrderStockUpdate.java
+++ b/src/test/java/tpi/backend/e_commerce/orderTests/unitTests/TestOrderStockUpdate.java
@@ -1,0 +1,40 @@
+package tpi.backend.e_commerce.orderTests.unitTests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tpi.backend.e_commerce.models.Product;
+import tpi.backend.e_commerce.services.product.ModifyProductService;
+
+
+
+/*Este test testeara la actualizacion de stock de los productos al registrar una orden
+Se registrara una orden para un producto cuyo stock actual es 10. Se compraran 5 unidades de ese producto
+y luego se verificara que el stock del producto sea de 5
+*/
+@ExtendWith(MockitoExtension.class)
+public class TestOrderStockUpdate {
+    
+    @InjectMocks
+    private ModifyProductService modifyProductService;
+    
+    Product product;
+    @BeforeEach
+    void setUp(){
+        product = new Product();
+        product.setStock(10L);
+    }
+
+    @Test
+    void testStockDiscount(){
+        product = modifyProductService.discountStock(product, 5);
+        assertEquals(5L, product.getStock());
+    }
+}


### PR DESCRIPTION
Se implemento el `caso de prueba 11`, que verifica el descuento de stock de un producto.
Se cambio la implementación del descuento de stock, que antes era responsabilidad del `saveOrderService`, para que ahora se encargue el `modifyProductService`. Esto con el objetivo de facilitar el test unitario y testear unicamente la funcionalidad de descuento de stock