### PR TITLE
Feat 72/auth sign up admin

### DIFF
--- a/src/main/java/tpi/backend/e_commerce/controllers/AuthenticationController.java
+++ b/src/main/java/tpi/backend/e_commerce/controllers/AuthenticationController.java
@@ -39,7 +39,8 @@ public class AuthenticationController {
         return authenticationService.signin(request,result);
     }
 
-    @PostMapping("/admin")
+    //Este endpoint sera utilizado para registrar el primer ADMIN en la BD (hardcodeo)
+    @PostMapping("/firstAdmin")
     public ResponseEntity<?> signUpAdmin(@Valid @RequestBody SignUpRequest userDto, BindingResult result){
         return saveService.signUpAdmin(userDto, result);
     }

--- a/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
+++ b/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -36,6 +37,10 @@ public class SignUpRequest {
     @Size(min = 8, max = 22, message = "Debe tener entre 8 y 22 caracteres")
     private String password;
 
-    private boolean isAdmin;
+    @NotNull
+    private String jwt;
+
+    @NotNull
+    private boolean admin;
 
 }

--- a/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
+++ b/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
@@ -36,4 +36,6 @@ public class SignUpRequest {
     @Size(min = 8, max = 22, message = "Debe tener entre 8 y 22 caracteres")
     private String password;
 
+    private boolean isAdmin;
+
 }

--- a/src/main/java/tpi/backend/e_commerce/mapper/UserMapper.java
+++ b/src/main/java/tpi/backend/e_commerce/mapper/UserMapper.java
@@ -28,14 +28,14 @@ public class UserMapper {
             .build();
     }
     
-    public static User toEntity(SignUpRequest userDto, String password, Role role){
+    public static User toEntity(SignUpRequest userDto, String password){
         return User
             .builder()
             .firstName(userDto.getFirstName())
             .lastName(userDto.getLastName())
             .email(userDto.getEmail())
             .password(password)
-            .role(role)
+            .role(userDto.isAdmin() ? Role.ADMIN : Role.USER)
             .dateBirth(userDto.getDateBirth())
             .build();
     }

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/AuthenticationService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/AuthenticationService.java
@@ -14,7 +14,6 @@ import org.springframework.validation.BindingResult;
 import lombok.RequiredArgsConstructor;
 import tpi.backend.e_commerce.dto.auth.request.SignInRequest;
 import tpi.backend.e_commerce.dto.auth.request.SignUpRequest;
-import tpi.backend.e_commerce.enums.Role;
 import tpi.backend.e_commerce.mapper.UserMapper;
 import tpi.backend.e_commerce.models.User;
 import tpi.backend.e_commerce.repositories.IUserRepository;

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/JwtService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/JwtService.java
@@ -15,6 +15,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import tpi.backend.e_commerce.enums.Role;
 import tpi.backend.e_commerce.services.JwtService.interfaces.IJwtService;
 
 @Service
@@ -28,8 +29,10 @@ public class JwtService implements IJwtService {
     }
 
     @Override
-    public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
+    public String generateToken(UserDetails userDetails, Role role) {
+        Map<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("Role", role);
+        return generateToken(extraClaims, userDetails);
     }
 
     @Override

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/JwtService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/JwtService.java
@@ -29,6 +29,11 @@ public class JwtService implements IJwtService {
     }
 
     @Override
+    public Role extractRole(String token) {
+        return extractClaim(token, claims -> Role.valueOf(claims.get("Role", String.class)));
+    }
+
+    @Override
     public String generateToken(UserDetails userDetails, Role role) {
         Map<String, Object> extraClaims = new HashMap<>();
         extraClaims.put("Role", role);

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/SaveUserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/SaveUserService.java
@@ -47,9 +47,10 @@ public class SaveUserService implements ISaveUserService{
         }
 
         // Si no hay errores, guarda al usuario en la BD y retorna el JWT
-        User user = UserMapper.toEntity(userDto, passwordEncoder.encode(userDto.getPassword()), Role.ADMIN);
+        User user = UserMapper.toEntity(userDto, passwordEncoder.encode(userDto.getPassword()));
+        user.setRole(Role.ADMIN); //HARDACODEADO, este endpoint se usara para probar la app
         userRepository.save(user);
-        String jwt = jwtService.generateToken(user);
+        String jwt = jwtService.generateToken(user, user.getRole());
         return ResponseEntity.ok(UserMapper.toJwtDto(user, jwt));
     }
 }

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IJwtService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IJwtService.java
@@ -2,10 +2,12 @@ package tpi.backend.e_commerce.services.JwtService.interfaces;
 
 import org.springframework.security.core.userdetails.UserDetails;
 
+import tpi.backend.e_commerce.enums.Role;
+
 public interface IJwtService {
     String extractUserName(String token);
 
-    String generateToken(UserDetails userDetails);
+    String generateToken(UserDetails userDetails, Role role);
 
     boolean isTokenValid(String token, UserDetails userDetails);
 }

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IJwtService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IJwtService.java
@@ -6,7 +6,8 @@ import tpi.backend.e_commerce.enums.Role;
 
 public interface IJwtService {
     String extractUserName(String token);
-
+    Role extractRole(String token);
+    
     String generateToken(UserDetails userDetails, Role role);
 
     boolean isTokenValid(String token, UserDetails userDetails);

--- a/src/main/java/tpi/backend/e_commerce/validation/Validation.java
+++ b/src/main/java/tpi/backend/e_commerce/validation/Validation.java
@@ -1,14 +1,22 @@
 package tpi.backend.e_commerce.validation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
+
+import tpi.backend.e_commerce.enums.Role;
+import tpi.backend.e_commerce.services.JwtService.JwtService;
+
 import java.util.Map;
 import java.util.Collections;
 import java.util.HashMap;
 
 @Component
 public class Validation {
+    
+    @Autowired
+    private JwtService jwtService;
     
     public ResponseEntity<Map<String,String>> validate(BindingResult result){
         Map<String,String> errors = new HashMap<>();
@@ -21,6 +29,13 @@ public class Validation {
 
     public ResponseEntity<Map<String,String>> validate(String field, String message, int status){
         return ResponseEntity.status(status).body(Collections.singletonMap(field, message));
+    }
+
+    public void validateRole(String jwt)throws Exception {
+        Role role = jwtService.extractRole(jwt);
+        if (!role.equals(Role.ADMIN)) {
+            throw new RuntimeException("Solo los usuarios con rol ADMIN pueden registrar otro usuario ADMIN");
+        }
     }
     
 }


### PR DESCRIPTION
Borre el endpoint `signUpAdmin`. Ahora para registrar usuarios de rol USER o de rol ADMIN se utilizara el endpoint `SignUp`. Si se quiere registrar a un usuario ADMIN, se validara mediante el JWT que el rol sea ADMIN (Solo un ADMIN puede registar a otro ADMIN)