### PR TITLE
Feat #89/auth endpoints

### DIFF
--- a/src/main/java/tpi/backend/e_commerce/controllers/AuthenticationController.java
+++ b/src/main/java/tpi/backend/e_commerce/controllers/AuthenticationController.java
@@ -6,6 +6,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,8 +30,10 @@ public class AuthenticationController {
 
     //Endpoint para registrar un usuario
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@Valid @RequestBody SignUpRequest request, BindingResult result) {
-        return authenticationService.signup(request,result);
+    public ResponseEntity<?> signup(
+        @Valid @RequestBody SignUpRequest request, BindingResult result, @RequestHeader("Authorization") String authorization
+        ) {
+        return authenticationService.signup(request,result,authorization);
     }   
 
     //Endpoint para autenticar al usuario en el inicio de sesion

--- a/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
+++ b/src/main/java/tpi/backend/e_commerce/dto/auth/request/SignUpRequest.java
@@ -38,9 +38,6 @@ public class SignUpRequest {
     private String password;
 
     @NotNull
-    private String jwt;
-
-    @NotNull
     private boolean admin;
 
 }

--- a/src/main/java/tpi/backend/e_commerce/middlewares/security/ForbiddenHandler.java
+++ b/src/main/java/tpi/backend/e_commerce/middlewares/security/ForbiddenHandler.java
@@ -1,0 +1,36 @@
+package tpi.backend.e_commerce.middlewares.security;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ForbiddenHandler implements AuthenticationEntryPoint{
+    
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+    AuthenticationException authException) throws IOException, ServletException {
+
+        Map<String,String> errors = new HashMap<>();
+        ObjectMapper mapper = new ObjectMapper();
+
+        errors.put("Authorization", "Se requiere un JWT valido.");
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json");
+        response.getWriter().write(mapper.writeValueAsString(errors)); 
+        //Convierte el Map a JSON y se lo pasa a la response
+    }
+}
+

--- a/src/main/java/tpi/backend/e_commerce/middlewares/security/JwtAuthenticationFilter.java
+++ b/src/main/java/tpi/backend/e_commerce/middlewares/security/JwtAuthenticationFilter.java
@@ -20,7 +20,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import tpi.backend.e_commerce.services.JwtService.JwtService;
-import tpi.backend.e_commerce.services.JwtService.UserService;
+import tpi.backend.e_commerce.services.user.UserService;
+
 import org.slf4j.Logger;
 
 @Component

--- a/src/main/java/tpi/backend/e_commerce/middlewares/security/SecurityConfiguration.java
+++ b/src/main/java/tpi/backend/e_commerce/middlewares/security/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package tpi.backend.e_commerce.middlewares.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -24,16 +25,23 @@ import tpi.backend.e_commerce.services.JwtService.UserService;
 public class SecurityConfiguration {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final UserService userService;
+    private final ForbiddenHandler forbiddenHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/auth/**", "/auth/signin","/user/**","/email/**", "/product/**", "/brand/**", "/category/**",
-                                "/subcategory/**","/orders/**", "/stock-entry/**","/v1/api-docs", "/swagger-resources/**",
+                        .requestMatchers("/auth/**","/email/**","/v1/api-docs", "/swagger-resources/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/swagger-ui.html")
-                        .permitAll().anyRequest().authenticated())
+                                "/swagger-ui.html").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/product", "/brand", "/category",
+                                "/subcategory","/orders/*").permitAll()
+                        .requestMatchers("/user/**" , "/product/**", "/brand/**", "/category/**",
+                                "/subcategory/**","/orders", "/stock-entry/**")
+                        .hasRole("ADMIN")
+                        .anyRequest()
+                        .authenticated())
+                .httpBasic(exception -> exception.authenticationEntryPoint(forbiddenHandler))
                 .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(authenticationProvider()).addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/tpi/backend/e_commerce/middlewares/security/SecurityConfiguration.java
+++ b/src/main/java/tpi/backend/e_commerce/middlewares/security/SecurityConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
-import tpi.backend.e_commerce.services.JwtService.UserService;
+import tpi.backend.e_commerce.services.user.UserService;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/tpi/backend/e_commerce/models/User.java
+++ b/src/main/java/tpi/backend/e_commerce/models/User.java
@@ -62,7 +62,7 @@ public class User implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" +role.name()));
     }
 
     @Override

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/AuthenticationService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/AuthenticationService.java
@@ -2,6 +2,7 @@ package tpi.backend.e_commerce.services.JwtService;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -49,6 +50,15 @@ public class AuthenticationService implements IAuthenticationService {
 
         //Si se quiere registrar a un ADMIN, se valida que el JWT enviado sea de un ADMIN
         if (request.isAdmin()) {
+            //Este if evita un nullPointerException si Authorization esta vacio o no tiene el formato correcto
+            if (StringUtils.isEmpty(authorization) || !StringUtils.startsWith(authorization, "Bearer ")) {
+                return validation.validate(
+                    "Authorization",
+                    "Se requiere un JWT valido.",
+                    403  
+                  );
+            }   
+            
             String requestJwt = authorization.replace("Bearer ", "");
             try {
                 validation.validateRole(requestJwt);

--- a/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IAuthenticationService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/JwtService/interfaces/IAuthenticationService.java
@@ -9,7 +9,7 @@ import tpi.backend.e_commerce.dto.auth.request.SignUpRequest;
 
 
 public interface IAuthenticationService {
-    ResponseEntity<?> signup(SignUpRequest request, BindingResult result);
+    ResponseEntity<?> signup(SignUpRequest request, BindingResult result, String authorization);
 
     ResponseEntity<?> signin(SignInRequest request, BindingResult result);
 }

--- a/src/main/java/tpi/backend/e_commerce/services/user/DeleteUserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/user/DeleteUserService.java
@@ -1,4 +1,4 @@
-package tpi.backend.e_commerce.services.JwtService;
+package tpi.backend.e_commerce.services.user;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/tpi/backend/e_commerce/services/user/FindUserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/user/FindUserService.java
@@ -1,4 +1,4 @@
-package tpi.backend.e_commerce.services.JwtService;
+package tpi.backend.e_commerce.services.user;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/tpi/backend/e_commerce/services/user/SaveUserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/user/SaveUserService.java
@@ -1,4 +1,4 @@
-package tpi.backend.e_commerce.services.JwtService;
+package tpi.backend.e_commerce.services.user;
 
 
 
@@ -13,6 +13,7 @@ import tpi.backend.e_commerce.enums.Role;
 import tpi.backend.e_commerce.mapper.UserMapper;
 import tpi.backend.e_commerce.models.User;
 import tpi.backend.e_commerce.repositories.IUserRepository;
+import tpi.backend.e_commerce.services.JwtService.JwtService;
 import tpi.backend.e_commerce.services.JwtService.interfaces.ISaveUserService;
 import tpi.backend.e_commerce.validation.Validation;
 

--- a/src/main/java/tpi/backend/e_commerce/services/user/UpdateUserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/user/UpdateUserService.java
@@ -1,4 +1,4 @@
-package tpi.backend.e_commerce.services.JwtService;
+package tpi.backend.e_commerce.services.user;
 
 import java.util.Optional;
 

--- a/src/main/java/tpi/backend/e_commerce/services/user/UserService.java
+++ b/src/main/java/tpi/backend/e_commerce/services/user/UserService.java
@@ -1,4 +1,4 @@
-package tpi.backend.e_commerce.services.JwtService;
+package tpi.backend.e_commerce.services.user;
 
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/test/java/tpi/backend/e_commerce/UserTests/UnitTests/Test6DontAceptDuplicateEmail.java
+++ b/src/test/java/tpi/backend/e_commerce/UserTests/UnitTests/Test6DontAceptDuplicateEmail.java
@@ -66,7 +66,7 @@ public class Test6DontAceptDuplicateEmail {
                         .body(Collections.singletonMap("email", "Ya existe un usuario con ese email")));
 
         // Llamar al servicio de autenticación
-        ResponseEntity<?> response = authenticationService.signup(request, result);
+        ResponseEntity<?> response = authenticationService.signup(request, result,"");
 
         // Verificar que el estado HTTP sea 409 CONFLICT
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode(), "Correo ya registrado");
@@ -94,7 +94,7 @@ public class Test6DontAceptDuplicateEmail {
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
 
         // Llamar al servicio de autenticación
-        ResponseEntity<?> response = authenticationService.signup(request, result);
+        ResponseEntity<?> response = authenticationService.signup(request, result,"");
 
         // Verificar que el estado HTTP sea 200 OK 
         assertEquals(HttpStatus.OK, response.getStatusCode(), "Correo válido");

--- a/src/test/java/tpi/backend/e_commerce/brandTests/unitTests/TestDeleteBrandWithProducts.java
+++ b/src/test/java/tpi/backend/e_commerce/brandTests/unitTests/TestDeleteBrandWithProducts.java
@@ -2,7 +2,6 @@ package tpi.backend.e_commerce.brandTests.unitTests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## Endpoints
Los siguientes endpoints requieren ahora de autenticacion mediante el `JWT`. 

- Post /auth/signup: Este endpoint ya recibia el JWT, pero mediante un atributo jwt ubicado en el body. Ahora lo recibira en el header mediante Authorization.
- /brand: Todos los endpoints menos los GET
- /category: Todos los endpoints menos los GET
- /sub-category: Todos los endpoints menos los GET
- /product: Todos los endpoints menos los GET
- Post /orders: GET orders (Historial de pedidos de cliente) no esta autorizado
- /user: Todos
- /stock-entry: Todos

## Autenticación
Para autenticarse, se debe añadir a la cabecera de la petición lo siguiente: 
```json
{
  "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c3VhcmlvIiwiZXhwIjoxNjk0Mzg5NjAwLCJyb2xlcyI6WyJBRE1JTiJdfQ.JpIKVvc9X1_YhBZ1OQMW9w4V9xR-RT0Oeu1OeA9EzoQ",
}
```
El JWT enviado debe tener el ROLE `ADMIN`. 
## Error
Si no se envia un JWT valido, el back devolvera lo siguiente:
![Image](https://github.com/user-attachments/assets/3964da38-c07c-4999-aa66-bd42de9d0763)

## SignUp ADMIN
Para registrar un usuario `ADMIN`, se debe utilizar el endpoint SignUp de la misma manera que se usa para registrar a un `USER`, unicamente se modifica este atributo de la peticion:
```json
{
    "admin": true
}
```
## Hardcodeo
Como es necesario tener un `JWT` de un usuario `ADMIN` para registrar otro `ADMIN`, la unica forma de registrar otro `ADMIN` es hardcodeandolo.
Para eso se creo el endpoint: `Post /auth/firstAdmin` el cual funciona igual que el signUp solo que para registrar a un usuario ADMIN no requiere autorizacion